### PR TITLE
fix: modify list inactive background color

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -85,7 +85,7 @@ export default function getTheme({ style, name, soft = false }) {
       'list.inactiveSelectionForeground': foreground,
       'list.activeSelectionForeground': foreground,
       'list.hoverBackground': activeBackground,
-      'list.inactiveSelectionBackground': background,
+      'list.inactiveSelectionBackground': activeBackground,
       'list.activeSelectionBackground': activeBackground,
       'list.inactiveFocusBackground': background,
       'list.focusBackground': activeBackground,

--- a/themes/vitesse-dark-soft.json
+++ b/themes/vitesse-dark-soft.json
@@ -53,7 +53,7 @@
     "list.inactiveSelectionForeground": "#dbd7caee",
     "list.activeSelectionForeground": "#dbd7caee",
     "list.hoverBackground": "#292929",
-    "list.inactiveSelectionBackground": "#222",
+    "list.inactiveSelectionBackground": "#292929",
     "list.activeSelectionBackground": "#292929",
     "list.inactiveFocusBackground": "#222",
     "list.focusBackground": "#292929",

--- a/themes/vitesse-dark.json
+++ b/themes/vitesse-dark.json
@@ -53,7 +53,7 @@
     "list.inactiveSelectionForeground": "#dbd7caee",
     "list.activeSelectionForeground": "#dbd7caee",
     "list.hoverBackground": "#181818",
-    "list.inactiveSelectionBackground": "#121212",
+    "list.inactiveSelectionBackground": "#181818",
     "list.activeSelectionBackground": "#181818",
     "list.inactiveFocusBackground": "#121212",
     "list.focusBackground": "#181818",

--- a/themes/vitesse-light-soft.json
+++ b/themes/vitesse-light-soft.json
@@ -53,7 +53,7 @@
     "list.inactiveSelectionForeground": "#393a34",
     "list.activeSelectionForeground": "#393a34",
     "list.hoverBackground": "#E7E5DB",
-    "list.inactiveSelectionBackground": "#F1F0E9",
+    "list.inactiveSelectionBackground": "#E7E5DB",
     "list.activeSelectionBackground": "#E7E5DB",
     "list.inactiveFocusBackground": "#F1F0E9",
     "list.focusBackground": "#E7E5DB",

--- a/themes/vitesse-light.json
+++ b/themes/vitesse-light.json
@@ -53,7 +53,7 @@
     "list.inactiveSelectionForeground": "#393a34",
     "list.activeSelectionForeground": "#393a34",
     "list.hoverBackground": "#f5f5f5",
-    "list.inactiveSelectionBackground": "#ffffff",
+    "list.inactiveSelectionBackground": "#f5f5f5",
     "list.activeSelectionBackground": "#f5f5f5",
     "list.inactiveFocusBackground": "#ffffff",
     "list.focusBackground": "#f5f5f5",


### PR DESCRIPTION
The list inactive section backround of the sidebar is not spotlight，it makes user hard to find where the opened file is:

![unfocus](https://user-images.githubusercontent.com/35717670/163206334-0cade420-6e38-41a6-a6b1-363cbd185f8d.png)

this situation is both existed in light or dark theme, so i have changed the background color to make it more sensible:

![fixed](https://user-images.githubusercontent.com/35717670/163206971-e1b27660-d62f-4ad9-9048-ae905e365ff9.png)
