### PR TITLE
fix: remove highlight for `source`. fix #18

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -491,7 +491,7 @@ export default function getTheme({ style, name, soft = false, black = false }) {
         },
       },
       {
-        scope: 'string source',
+        scope: 'string',
         settings: {
           foreground,
         },

--- a/themes/vitesse-black.json
+++ b/themes/vitesse-black.json
@@ -423,7 +423,7 @@
       }
     },
     {
-      "scope": "string source",
+      "scope": "string",
       "settings": {
         "foreground": "#dbd7caee"
       }
@@ -936,7 +936,7 @@
       "foreground": "fdaeb7"
     },
     {
-      "token": "string source",
+      "token": "string",
       "foreground": "dbd7caee"
     },
     {

--- a/themes/vitesse-dark-soft.json
+++ b/themes/vitesse-dark-soft.json
@@ -423,7 +423,7 @@
       }
     },
     {
-      "scope": "string source",
+      "scope": "string",
       "settings": {
         "foreground": "#dbd7caee"
       }
@@ -936,7 +936,7 @@
       "foreground": "fdaeb7"
     },
     {
-      "token": "string source",
+      "token": "string",
       "foreground": "dbd7caee"
     },
     {

--- a/themes/vitesse-dark.json
+++ b/themes/vitesse-dark.json
@@ -423,7 +423,7 @@
       }
     },
     {
-      "scope": "string source",
+      "scope": "string",
       "settings": {
         "foreground": "#dbd7caee"
       }
@@ -936,7 +936,7 @@
       "foreground": "fdaeb7"
     },
     {
-      "token": "string source",
+      "token": "string",
       "foreground": "dbd7caee"
     },
     {

--- a/themes/vitesse-light-soft.json
+++ b/themes/vitesse-light-soft.json
@@ -421,7 +421,7 @@
       }
     },
     {
-      "scope": "string source",
+      "scope": "string",
       "settings": {
         "foreground": "#393a34"
       }
@@ -934,7 +934,7 @@
       "foreground": "b31d28"
     },
     {
-      "token": "string source",
+      "token": "string",
       "foreground": "393a34"
     },
     {

--- a/themes/vitesse-light.json
+++ b/themes/vitesse-light.json
@@ -421,7 +421,7 @@
       }
     },
     {
-      "scope": "string source",
+      "scope": "string",
       "settings": {
         "foreground": "#393a34"
       }
@@ -934,7 +934,7 @@
       "foreground": "b31d28"
     },
     {
-      "token": "string source",
+      "token": "string",
       "foreground": "393a34"
     },
     {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Remove `source` definition in the theme, so it uses fallback color and doesn't override other token's color.

### Linked Issues

#18 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
