### PR TITLE
feat: menu separator color

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -256,6 +256,8 @@ export default function getTheme({ style, name, soft = false, black = false }) {
 
       'editorStickyScroll.background': activeBackground,
       'editorStickyScrollHover.background': activeBackground,
+
+      'menu.separatorBackground': border,
     },
     semanticHighlighting: true,
     semanticTokenColors: {

--- a/themes/vitesse-black.json
+++ b/themes/vitesse-black.json
@@ -184,7 +184,8 @@
     "editorInlayHint.foreground": "#666666",
     "editorInlayHint.background": "#00000000",
     "editorStickyScroll.background": "#050505",
-    "editorStickyScrollHover.background": "#050505"
+    "editorStickyScrollHover.background": "#050505",
+    "menu.separatorBackground": "#191919"
   },
   "semanticHighlighting": true,
   "semanticTokenColors": {

--- a/themes/vitesse-dark-soft.json
+++ b/themes/vitesse-dark-soft.json
@@ -184,7 +184,8 @@
     "editorInlayHint.foreground": "#666666",
     "editorInlayHint.background": "#00000000",
     "editorStickyScroll.background": "#292929",
-    "editorStickyScrollHover.background": "#292929"
+    "editorStickyScrollHover.background": "#292929",
+    "menu.separatorBackground": "#252525"
   },
   "semanticHighlighting": true,
   "semanticTokenColors": {

--- a/themes/vitesse-dark.json
+++ b/themes/vitesse-dark.json
@@ -184,7 +184,8 @@
     "editorInlayHint.foreground": "#666666",
     "editorInlayHint.background": "#00000000",
     "editorStickyScroll.background": "#181818",
-    "editorStickyScrollHover.background": "#181818"
+    "editorStickyScrollHover.background": "#181818",
+    "menu.separatorBackground": "#191919"
   },
   "semanticHighlighting": true,
   "semanticTokenColors": {

--- a/themes/vitesse-light-soft.json
+++ b/themes/vitesse-light-soft.json
@@ -182,7 +182,8 @@
     "editorInlayHint.foreground": "#999999",
     "editorInlayHint.background": "#00000000",
     "editorStickyScroll.background": "#E7E5DB",
-    "editorStickyScrollHover.background": "#E7E5DB"
+    "editorStickyScrollHover.background": "#E7E5DB",
+    "menu.separatorBackground": "#E7E5DB"
   },
   "semanticHighlighting": true,
   "semanticTokenColors": {

--- a/themes/vitesse-light.json
+++ b/themes/vitesse-light.json
@@ -182,7 +182,8 @@
     "editorInlayHint.foreground": "#999999",
     "editorInlayHint.background": "#00000000",
     "editorStickyScroll.background": "#f7f7f7",
-    "editorStickyScrollHover.background": "#f7f7f7"
+    "editorStickyScrollHover.background": "#f7f7f7",
+    "menu.separatorBackground": "#f0f0f0"
   },
   "semanticHighlighting": true,
   "semanticTokenColors": {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

On Windows, the menu separator color is a bit stand-out compared to the rest of the theme.

![CEC418B8-7DBF-491F-9CCD-8FB158C0F139](https://user-images.githubusercontent.com/75784849/221464914-0b8f3b4e-fab1-48a9-8723-12193e9f6eb8.png)

So I added the separator color to match with the border color the theme is using.

![19FD1617-E3B7-43B0-9278-5BB0BE9EAF29](https://user-images.githubusercontent.com/75784849/221465040-e1de7fa4-0aae-4899-8b65-8ef47dd976d4.png)


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
