### PR TITLE
Fix low contrast on gitignored files for vitesse black theme

### DIFF
--- a/themes/vitesse-black.json
+++ b/themes/vitesse-black.json
@@ -149,7 +149,7 @@
     "gitDecoration.modifiedResourceForeground": "#6394bf",
     "gitDecoration.deletedResourceForeground": "#cb7676",
     "gitDecoration.untrackedResourceForeground": "#5eaab5",
-    "gitDecoration.ignoredResourceForeground": "#dedcd530",
+    "gitDecoration.ignoredResourceForeground": "#817878",
     "gitDecoration.conflictingResourceForeground": "#d4976c",
     "gitDecoration.submoduleResourceForeground": "#dedcd590",
     "editorGutter.modifiedBackground": "#6394bf",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR makes gitignored files default readable instead of unreadable
# Before
![image](https://user-images.githubusercontent.com/44563205/224536017-71ac9822-4d5b-4243-987c-61157e555556.png)

# After
![image](https://user-images.githubusercontent.com/44563205/224536031-5c8bb3ac-632b-4d2b-8ac6-bd8201c07ef9.png)

I do realised that themes are a personal thing but feel that by default the text should always be readable hence the PR.

Feel free to close it if you don't like it!

### Linked Issues

#21 

### Additional context


