### PR TITLE
ci: update release workflow to use Node.js v16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           registry-url: https://registry.npmjs.org/
       - run: npm i -g pnpm @antfu/ni
       - run: nci


### PR DESCRIPTION
### Description

The latest version, `v0.7.0`, did not get a [GitHub release](https://github.com/antfu/vscode-theme-vitesse/releases) or published to the [npm registry](https://www.npmjs.com/package/theme-vitesse?activeTab=versions). This is due to a [release workflow failure](https://github.com/antfu/vscode-theme-vitesse/actions/runs/4925894566/jobs/8800686143) that is related to a Node.js version issue:

- The workflow [uses Node.js v14.X](https://github.com/antfu/vscode-theme-vitesse/blob/d7c8d598812ff8aa42285c3b85ad9efc7563ebee/.github/workflows/release.yml#L17).
- The latest version of `pnpm` is [installed](https://github.com/antfu/vscode-theme-vitesse/blob/d7c8d598812ff8aa42285c3b85ad9efc7563ebee/.github/workflows/release.yml#L19).

Altho, pnpm v8 is [only compatible with Node.js v16+](https://pnpm.io/installation#compatibility) which leads to the following workflow error:

```sh
ERROR: This version of pnpm requires at least Node.js v16.14
The current version of Node.js is v14.21.3
```

This pull request updates the Node.js version used by the release workflow to the latest v16 version which I tested locally with the `build` npm script and it worked fine. I guess there are other ways to fix this issue like pinning the pnpm version to `v7.X`, etc. so if you prefer another solution, please let me know.

### Linked Issues

None

### Additional context

None
