### PR TITLE
fix: fix the color of `list.focusBackground` is not obvious

### DIFF
--- a/scripts/theme.ts
+++ b/scripts/theme.ts
@@ -94,7 +94,7 @@ export default function getTheme(options: GetThemeOptions) {
       'list.inactiveSelectionBackground': activeBackground,
       'list.activeSelectionBackground': activeBackground,
       'list.inactiveFocusBackground': background,
-      'list.focusBackground': activeBackground,
+      'list.focusBackground': background,
       'list.highlightForeground': primary,
 
       'tree.indentGuidesStroke': pick({ light: colors.gray[2], dark: colors.gray[1] }),

--- a/themes/vitesse-black.json
+++ b/themes/vitesse-black.json
@@ -56,7 +56,7 @@
     "list.inactiveSelectionBackground": "#121212",
     "list.activeSelectionBackground": "#121212",
     "list.inactiveFocusBackground": "#000",
-    "list.focusBackground": "#121212",
+    "list.focusBackground": "#000",
     "list.highlightForeground": "#4d9375",
     "tree.indentGuidesStroke": "#2f363d",
     "notificationCenterHeader.foreground": "#959da5",

--- a/themes/vitesse-dark-soft.json
+++ b/themes/vitesse-dark-soft.json
@@ -56,7 +56,7 @@
     "list.inactiveSelectionBackground": "#292929",
     "list.activeSelectionBackground": "#292929",
     "list.inactiveFocusBackground": "#222",
-    "list.focusBackground": "#292929",
+    "list.focusBackground": "#222",
     "list.highlightForeground": "#4d9375",
     "tree.indentGuidesStroke": "#2f363d",
     "notificationCenterHeader.foreground": "#959da5",

--- a/themes/vitesse-dark.json
+++ b/themes/vitesse-dark.json
@@ -56,7 +56,7 @@
     "list.inactiveSelectionBackground": "#181818",
     "list.activeSelectionBackground": "#181818",
     "list.inactiveFocusBackground": "#121212",
-    "list.focusBackground": "#181818",
+    "list.focusBackground": "#121212",
     "list.highlightForeground": "#4d9375",
     "tree.indentGuidesStroke": "#2f363d",
     "notificationCenterHeader.foreground": "#959da5",

--- a/themes/vitesse-light-soft.json
+++ b/themes/vitesse-light-soft.json
@@ -56,7 +56,7 @@
     "list.inactiveSelectionBackground": "#E7E5DB",
     "list.activeSelectionBackground": "#E7E5DB",
     "list.inactiveFocusBackground": "#F1F0E9",
-    "list.focusBackground": "#E7E5DB",
+    "list.focusBackground": "#F1F0E9",
     "list.highlightForeground": "#1c6b48",
     "tree.indentGuidesStroke": "#e1e4e8",
     "notificationCenterHeader.foreground": "#6a737d",

--- a/themes/vitesse-light.json
+++ b/themes/vitesse-light.json
@@ -56,7 +56,7 @@
     "list.inactiveSelectionBackground": "#f7f7f7",
     "list.activeSelectionBackground": "#f7f7f7",
     "list.inactiveFocusBackground": "#ffffff",
-    "list.focusBackground": "#f7f7f7",
+    "list.focusBackground": "#ffffff",
     "list.highlightForeground": "#1c6b48",
     "tree.indentGuidesStroke": "#e1e4e8",
     "notificationCenterHeader.foreground": "#6a737d",


### PR DESCRIPTION
### Description

When I uncheck a list after selecting all, I can't see it clearly. 😵

The background color that is deselected should be the same as the editor.

![image](https://github.com/antfu/vscode-theme-vitesse/assets/47177021/17d3f84d-eea1-410b-8807-8d3e93bdc531)

Now, it's look like great. 😎

![image](https://github.com/antfu/vscode-theme-vitesse/assets/47177021/3b2ba90f-c163-456a-b5f2-77094a2ec289)

### Linked Issues

not yet.

### Additional context

not yet.