### PR TITLE
fix: fixed clipping from termina.ansiwhite transparency

### DIFF
--- a/themes/vitesse-dark-soft.json
+++ b/themes/vitesse-dark-soft.json
@@ -145,7 +145,7 @@
     "terminal.ansiGreen": "#4d9375",
     "terminal.ansiMagenta": "#d9739f",
     "terminal.ansiRed": "#cb7676",
-    "terminal.ansiWhite": "#dbd7caee",
+    "terminal.ansiWhite": "#dbd7ca",
     "terminal.ansiYellow": "#e6cc77",
     "gitDecoration.addedResourceForeground": "#4d9375",
     "gitDecoration.modifiedResourceForeground": "#6394bf",


### PR DESCRIPTION
### Description

There was distortion with my command-line prompts that seemed to be caused by transparency in `terminal.ansi*` colors for vitesse-dark-soft. 

![image](https://github.com/antfu/vscode-theme-vitesse/assets/50436165/1f04c272-314b-4804-9151-77d489ddbf19)

Once, transparency is removed, everything is back looking like it should. :)
![image](https://github.com/antfu/vscode-theme-vitesse/assets/50436165/1ebe9df6-8d1f-46ce-a51f-ded54baf80c9)

### Linked Issues

### Additional context

The same issue happens when I add transparency to any of the other `terminal.ansi*` colors, but `terminal.ansiWhite` is the only color (in vitesse-dark-soft) currently with transparency .
![image](https://github.com/antfu/vscode-theme-vitesse/assets/50436165/f2ca3e26-409c-43b8-93f8-58e765384155)
