### PR TITLE
fix: fix focusBackground color

### DIFF
--- a/scripts/theme.ts
+++ b/scripts/theme.ts
@@ -94,7 +94,7 @@ export default function getTheme(options: GetThemeOptions) {
       'list.inactiveSelectionBackground': activeBackground,
       'list.activeSelectionBackground': activeBackground,
       'list.inactiveFocusBackground': background,
-      'list.focusBackground': background,
+      'list.focusBackground': activeBackground,
       'list.highlightForeground': primary,
 
       'tree.indentGuidesStroke': pick({ light: colors.gray[2], dark: colors.gray[1] }),


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

It seems to be related to the changes in #30. 
I modified the focusBackground to resolve #31 .

(Can see the background color)
![螢幕錄影 2024-04-04 凌晨2 17 05](https://github.com/antfu/vscode-theme-vitesse/assets/93901409/c9c834d1-2491-4e03-8ef9-1a4fb6e7d2d7)

(Moving, but cannot see the background color)
![螢幕錄影 2024-04-04 凌晨2 18 43](https://github.com/antfu/vscode-theme-vitesse/assets/93901409/5325c36c-2860-45d2-88c0-d4044723a3fb)


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

Not sure if such a modification will conflict with #30.