### PR TITLE
Upload .vsix file to release page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
+      actions: write
 
     runs-on: ubuntu-latest
     steps:
@@ -28,12 +29,27 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: pnpm
 
-      - run: pnpm install
-
       - run: npx changelogithub --no-group
         continue-on-error: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - run: pnpm install
+
+      - name: Generate .vsix file
+        run: pnpm package
+
+      - name: Upload .vsix to Release
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          ASSET_NAME="theme-vitesse-${VERSION}.vsix"
+
+          TAG_NAME="${GITHUB_REF#refs/tags/}"
+          REPO="${{ github.repository }}"
+
+          gh release upload "$TAG_NAME" "./${ASSET_NAME}" --repo "$REPO" --clobber
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - run: npm publish --access public
         env:

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
     "release": "bumpp --all && vsce publish --no-dependencies",
-    "pack": "vsce pack --no-dependencies"
+    "pack": "vsce pack --no-dependencies",
+    "package": "vsce package --no-dependencies"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.25.2",


### PR DESCRIPTION
### Description

This PR adds the ability to upload the `.vsix` file of `vscode-theme-vitesse` to the Release page. enabling local installation of the theme for VSCode forks like `cursor` and `windsurf`.

The current version of the theme on Open-VSX has not been updated in over 4 years, making this change necessary for up-to-date installations.

### Linked Issues

- [#26](https://github.com/antfu/vscode-theme-vitesse/issues/26)
- [#17](https://github.com/antfu/vscode-theme-vitesse/issues/17)