### PR TITLE
ci: add release workflow for marketplace, openvsx and github

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Package
+name: Publish Extension
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - v*
 
 jobs:
-  publish-npm:
+  publish-extension:
     permissions:
       id-token: write
       contents: write
@@ -22,11 +22,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
 
-      - name: Use Node.js v18
-        uses: actions/setup-node@v3
+      - name: Set node
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
-          registry-url: https://registry.npmjs.org/
+          node-version: lts/*
           cache: pnpm
 
       - run: npx changelogithub --no-group
@@ -39,19 +38,9 @@ jobs:
       - name: Generate .vsix file
         run: pnpm package
 
-      - name: Upload .vsix to Release
-        run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
-          ASSET_NAME="theme-vitesse-${VERSION}.vsix"
-
-          TAG_NAME="${GITHUB_REF#refs/tags/}"
-          REPO="${{ github.repository }}"
-
-          gh release upload "$TAG_NAME" "./${ASSET_NAME}" --repo "$REPO" --clobber
+      - name: Publish Extension
+        run: npx vsxpub --no-dependencies
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-          NPM_CONFIG_PROVENANCE: true
+          VSCE_PAT: ${{secrets.VSCE_PAT}}
+          OVSX_PAT: ${{secrets.OVSX_PAT}}

--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "vscode:prepublish": "npm run build",
     "lint": "eslint .",
     "prepublishOnly": "npm run build",
-    "release": "bumpp --all && vsce publish --no-dependencies",
-    "pack": "vsce pack --no-dependencies",
+    "release": "bumpp --all",
     "package": "vsce package --no-dependencies"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

This PR implements automated publishing of the VS Code extension through CI, with simultaneous releases to:
1. Visual Studio Marketplace
2. OpenVSX registry (for open-source VS Code alternatives)
3. GitHub Release page

The implementation will:
- Add CI workflow for automated publishing
- Handle version synchronization across all platforms
- Require `VSCE_PAT` (for VS Marketplace) and `OVSX_PAT` (for OpenVSX) secrets to be configured in the repository

### Additional context

For managing these secrets across multiple repositories, consider using the [gh-secrets-sync](https://github.com/jinghaihan/gh-secrets-sync) tool which can:
- Be run locally or configured in a central repository
- Synchronize secrets to multiple repositories at once
